### PR TITLE
Dont use suffix when creating provider

### DIFF
--- a/lib/formatOptions.coffee
+++ b/lib/formatOptions.coffee
@@ -18,7 +18,7 @@ module.exports = (options) ->
 			format: 'camelCase'
 		provider:
 			format: 'camelCase'
-			suffix: 'Provider'
+			#suffix: 'Provider'
 		service:
 			format: 'camelCase'
 			suffix: 'Service'


### PR DESCRIPTION
angular will automatically add "Provider" suffix (https://docs.angularjs.org/guide/providers)