### PR TITLE
makes coffee-script a peer-dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - 0.10
+before_install:
+  - npm i npm -g
 notifications:
   email:
     on_success: always

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		"node": ">=0.10.0"
 	},
 	"dependencies": {
-		"coffee-script": "^1.7.1",
 		"loophole": "^1.0.0",
 		"node.extend": "^1.0.10"
 	},
@@ -36,6 +35,9 @@
 		"gulp-jasmine": "^2.0.1",
 		"gulp-rename": "^1.2.0",
 		"gulp-util": "^3.0.0"
+	},
+	"peerDependencies": {
+		"coffee-script": "^1.7.1"
 	},
 	"scripts": {
 		"test": "gulp test"


### PR DESCRIPTION
Making coffee-script a peer-dependency would prevent coffee from being downloaded once again just to use this library. If coffee-script is not explicitly listed, npm will automatically install coffee-script as per npm’s documentation anyways.
